### PR TITLE
Update the port for easy server access

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { Tree, Bush, Crate, Stone, MosinTree, SovietCrate } from "./store/obstac
 
 export var ticksElapsed = 0;
 
-const server = new ws.Server({ port: 8080 });
+const server = new ws.Server({ port: 80 });
 server.once("listening", () => console.log(`WebSocket Server listening at port ${server.options.port}`));
 
 const sockets = new Map<string, ws.WebSocket>();


### PR DESCRIPTION
I changed the port to 80, because, when using servers, that are not locally hosted (ie, not localhost), and on a different pc, well, then IP addresses won't work, and currently, afaik, there is no support for IP:Port combo with the current regex check.