### PR TITLE
fix player fist flicker and scope getting a name 

### DIFF
--- a/client/src/store/entities/scope.ts
+++ b/client/src/store/entities/scope.ts
@@ -34,6 +34,7 @@ export default class Scope extends Entity {
 
 	copy(minEntity: MinEntity & AdditionalEntity) {
 		super.copy(minEntity);
+		this.name = minEntity.name;
 		this.zoom = minEntity.zoom;
 	}
 

--- a/client/src/store/entities/scope.ts
+++ b/client/src/store/entities/scope.ts
@@ -7,6 +7,7 @@ import Player from "./player";
 
 interface AdditionalEntity {
 	zoom: number;
+	name: string;
 }
 
 class ScopeSupplier implements EntitySupplier {
@@ -17,6 +18,7 @@ class ScopeSupplier implements EntitySupplier {
 
 export default class Scope extends Entity {
 	static readonly TYPE = "scope";
+	name!: string
 	type = Scope.TYPE;
 	zoom!: number;
 	zIndex = 8;

--- a/client/src/types/weapon.ts
+++ b/client/src/types/weapon.ts
@@ -38,7 +38,7 @@ export class MeleeWeapon extends Weapon {
 	}
 
 	render(player: Player, _canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, scale: number) {
-		if (!this.currentSkinSVG.src) this.currentSkinSVG.src = "assets/images/game/fists/" + player.skin + ".svg";
+		this.currentSkinSVG.src = "assets/images/game/fists/" + player.skin + ".svg";
 		const radius = scale * (<CircleHitbox> player.hitbox).radius;
 		const fistScale = radius * 1.2 * CommonNumber.SIN45;
 		const fistExtend = Vec2.UNIT_X.scaleAll(fistScale);

--- a/server/src/store/entities/scope.ts
+++ b/server/src/store/entities/scope.ts
@@ -5,12 +5,14 @@ import Player from "./player";
 
 export default class Scope extends Item {
 	type = "scope";
+	name: string;
 	hitbox = new CircleHitbox(1);
 	zoom: number;
 
 	constructor(zoom: number) {
 		super();
 		this.zoom = zoom;
+		this.name = `${this.zoom}x scope`
 	}
 
 	picked(player: Player) {


### PR DESCRIPTION
player fist flickering fix and the scope entity now has a `name` property so when being over it should show "Pick up 8x scope" or whatever instead of "pick up  null"